### PR TITLE
修复编译脚本报错“no Go files in xxxx”

### DIFF
--- a/build/build.cmd
+++ b/build/build.cmd
@@ -10,7 +10,7 @@ cd ..
 SET ROOT=%CD%
 
 echo Building %SERVER%
-cd %ROOT%\cmd
+cd %ROOT%\cmd\api
 go build -o %BLDIR%\%SERVER%.exe .
 
 echo Build done


### PR DESCRIPTION
执行编译脚本build.cmd会报错，发现是切换路径没有写对，简单修改了下